### PR TITLE
Fix devcontainer: Add write permissions for /workspaces directory

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,5 +53,8 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME 
 
+# Create /workspaces directory and set ownership for csp user
+RUN mkdir -p /workspaces && chown -R $USERNAME:$USERNAME /workspaces
+
 USER $USERNAME
 


### PR DESCRIPTION
## Problem
The devcontainer's postCreateCommand fails when trying to clone STM32CubeG0 and STM32CubeG4 repositories to `/workspaces/` because the non-root user (`csp`) lacks write permissions to that directory.

## Solution
This PR creates the `/workspaces` directory and sets proper ownership before switching to the non-root user in the Dockerfile.

## Changes
- Modified `.devcontainer/Dockerfile` to create `/workspaces` directory with correct ownership for the `csp` user

## Testing
- Rebuilt the devcontainer
- Verified that STM32CubeG0 and STM32CubeG4 repositories clone successfully to `/workspaces/` during container initialization
- Confirmed existing functionality remains unchanged